### PR TITLE
커뮤니티 카드리스트 조회 에러 수정

### DIFF
--- a/lib/screens/community/community_screen.dart
+++ b/lib/screens/community/community_screen.dart
@@ -33,6 +33,9 @@ class _CommunityScreenState extends ConsumerState<CommunityScreen> {
     if (_calendars.isNotEmpty) {
       _lastUpdatedAt = DateTime.parse(_calendars.last.updatedAt as String); // 초기화 시 마지막 게시물의 updatedAt 저장
     }
+
+    //이러면 api에서 반환하는 hasNext 값에 상관없이 무조건 true가 저장된다. 08/09
+    //s_main 파일에서 CommunityScreen생성자를 호출할 때 hasNext값도 넘겨줘야 한다.
     _hasNext = _calendars.isNotEmpty;
   }
 
@@ -48,7 +51,8 @@ class _CommunityScreenState extends ConsumerState<CommunityScreen> {
         // 중복 항목 제거
         _calendars.addAll(fetchedCalendars.where((newCalendar) => !_calendars.any((existingCalendar) => existingCalendar.id == newCalendar.id)));
         _hasNext = result['hasNext'];
-        if (fetchedCalendars.isNotEmpty) {
+        // hasNext 값으로 다음 리스트가 있을경우 다음 리스트를 불러오기위해 lastupdatedat 변수 업데이트 08/09
+        if (_hasNext) {
           _lastUpdatedAt = DateTime.parse(fetchedCalendars.last.updatedAt as String); // 새로운 마지막 게시물의 updatedAt 저장
         }
       });

--- a/lib/services/community_service.dart
+++ b/lib/services/community_service.dart
@@ -23,14 +23,16 @@ class CommunityService {
     }
 
     try {
-      String uri = '$baseUrl/calendars?size=10';
+      /*String uri = '$baseUrl/calendars?size=10';
       if (lastUpdatedAt != null) {
         uri += '&updated_at=${lastUpdatedAt.toIso8601String()}';
-      }
-
+      }*/
+      String uri = '$baseUrl/calendars';
+      String? time = lastUpdatedAt?.toIso8601String();
       print('Request URI: $uri');
       final response = await dio.get(
         uri,
+        queryParameters: {'time' : time},
         options: Options(
           headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
커뮤니티 탭 오류 원인파악후 에러 수정하여 PR 요청드립니다. 
이번 커뮤니티 탭에서 이슈가 발생한 원인은 아래와 같습니다.

1.탭을 눌렀을 때 10개의 커뮤니티 카드가 떠야되는데 현재 9개뜨고있음
-> 이건 백엔드에서 저장하고 있는 리스트가 9개밖에 없었어서 발생한 문제로 보임, 금일 낮에 디버깅했을때 해당 api에서 리스트 9개 반환하고 hasnex값은 false를 반환하고 있었음, 근데 저녁에 다시 디버깅해보니 리스트 10개를 반환하고, hasnext 값은 true를 반환하는걸 확인함

2.두 번째 조회시 탭이 추가로 떠야하는데 안뜨고있음
-> 해당 api에 파라미터를 전달해주는 방식에 문제가 있던것으로 확인함
url 주소에 파라미터를 넘겨주는 것이 아닌, queryparameter 매개변수에 time값을 넘겨주니 그 다음 리스트가 정상적으로 반환됨
또한 size는 default가 10이므로 따로 매개변수로 넘겨주지는 않았음

이렇게 이슈사항들을 확인하고 수정하였습니다.

다만 수정이 필요한 부분이 보여서 이 부분은 하늘님이 수정해주시면 될 것 같습니다. 이번에 제가 수정한 부분과 수정을 요청한 코드 부분에  "08/09" 텍스트와 함께 주석을 남겨서 검색하셔서 수정해주시면 될 것 같습니다.